### PR TITLE
npm install as user running the service (with specific node version)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-deb-pkg",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Debian packaging for Node.js projects, fork of node-deb (https://github.com/heartsucker/node-deb) with additional features. Not intended to be maintained (but maybe merged one day)",
   "author": "fabien (https://github.com/f-ld)",
   "bin": {

--- a/templates/postinst
+++ b/templates/postinst
@@ -70,7 +70,7 @@ start_service () {
 }
 
 npm_install() {
-  cd "{{ node_deb_install_path }}/$1/app"
+  cd "{{ node_deb_install_path }}/{{ node_deb_package_name }}/app"
   if [ -e 'node_modules' ]; then
     rm -rf 'node_modules'
   fi
@@ -79,7 +79,8 @@ npm_install() {
 
 addGroup '{{ node_deb_group }}' ''
 addUser '{{ node_deb_user }}' '' '{{ node_deb_group }}' '{{ node_deb_user }} user-daemon' '/bin/false'
-npm_install '{{ node_deb_package_name }}'
+export -f npm_install
+su '{{ node_deb_user }}' -c "bash -l -c npm_install"
 
 if ! [ -d '/var/log/{{ node_deb_package_name }}' ]; then
   mkdir -p '/var/log/{{ node_deb_package_name }}'


### PR DESCRIPTION
On some hosts `nvm` can be used to install a specific nodejs version for some users (and different versions for different users and different services) and the npm install has to be done with that nodejs version. So we need to run it with the user that is going to run the service